### PR TITLE
Bump max ide version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ intellijPlatform {
         version = project.version.toString()
         ideaVersion {
             sinceBuild = "243"
-            untilBuild = "252.*"
+            untilBuild = "253.*"
         }
     }
     pluginVerification {
@@ -91,7 +91,7 @@ intellijPlatform {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
                 channels.set(listOf(ProductRelease.Channel.RELEASE))
                 sinceBuild = "243"
-                untilBuild = "252.*"
+                untilBuild = "253.*"
             }
         }
     }


### PR DESCRIPTION
2025.3 is around the corner, without this bump we get 1.0 of the plugin installed, which doesn't work properly.
Should fix https://github.com/Mishkun/ataman-intellij/issues/34 and https://github.com/Mishkun/ataman-intellij/issues/32

@Mishkun could you take a look, please?