### PR TITLE
Bump max ide version for intellij 2026.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ intellijPlatform {
         version = project.version.toString()
         ideaVersion {
             sinceBuild = "243"
-            untilBuild = "253.*"
+            untilBuild = "261.*"
         }
     }
     pluginVerification {
@@ -91,7 +91,7 @@ intellijPlatform {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
                 channels.set(listOf(ProductRelease.Channel.RELEASE))
                 sinceBuild = "243"
-                untilBuild = "253.*"
+                untilBuild = "261.*"
             }
         }
     }


### PR DESCRIPTION
2026.1 is in beta, without this bump we get 1.0 of the plugin installed, which doesn't work properly.

@Mishkun could you take a look, please?