### PR TITLE
Backport of bump max ide version for intellij 2026.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ intellijPlatform {
         version = project.version.toString()
         ideaVersion {
             sinceBuild = "243"
-            untilBuild = "253.*"
+            untilBuild = "261.*"
         }
     }
     pluginVerification {
@@ -91,7 +91,7 @@ intellijPlatform {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
                 channels.set(listOf(ProductRelease.Channel.RELEASE))
                 sinceBuild = "243"
-                untilBuild = "253.*"
+                untilBuild = "261.*"
             }
         }
     }


### PR DESCRIPTION
Backported bump of ide version to v2.0.0-rc, so that it would work in intellij 2026.1

@Mishkun could you take a look and create v2.0.0-rc2 release, please?