### PR TITLE
Bump max IDE version to 2026.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,7 +82,7 @@ intellijPlatform {
         version = project.version.toString()
         ideaVersion {
             sinceBuild = "243"
-            untilBuild = "261.*"
+            untilBuild = "262.*"
         }
     }
     pluginVerification {
@@ -91,7 +91,7 @@ intellijPlatform {
                 types.set(listOf(IntelliJPlatformType.IntellijIdeaCommunity))
                 channels.set(listOf(ProductRelease.Channel.RELEASE))
                 sinceBuild = "243"
-                untilBuild = "261.*"
+                untilBuild = "262.*"
             }
         }
     }


### PR DESCRIPTION
Hello @Mishkun! It's that time of year again 😁

Made a bump of max IDE version as 2026.2 is in [RC stage](https://youtrack.jetbrains.com/articles/WI-A-231736361/PhpStorm-2026.2-RC-262.8665.184-build-Release-Notes)

